### PR TITLE
Added category for custom sniff

### DIFF
--- a/Yii2/Sniffs/Properties/PrivatePropertiesUnderscoreSniff.php
+++ b/Yii2/Sniffs/Properties/PrivatePropertiesUnderscoreSniff.php
@@ -1,6 +1,6 @@
 <?php
 
-class Yii2_Sniffs_PrivatePropertiesUnderscoreSniff implements PHP_CodeSniffer_Sniff
+class Yii2_Sniffs_Properties_PrivatePropertiesUnderscoreSniff implements PHP_CodeSniffer_Sniff
 {
 	public function register()
 	{


### PR DESCRIPTION
PHP_CodeSniffer requires all custom sniffs to have a category (exist in a category directory and have the category in their class name). Fixes issue #5.
