### PR TITLE
only exclude the Underscore part of PSR2.Classes.PropertyDeclaration

### DIFF
--- a/Yii2/ruleset.xml
+++ b/Yii2/ruleset.xml
@@ -4,7 +4,7 @@
 
 	<rule ref="PSR2">
 		<!-- Property names MUST start with an initial underscore if they are private. -->
-		<exclude name="PSR2.Classes.PropertyDeclaration"/>
+		<exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>
 
 		<!-- Opening parenthesis of a multi-line function call must be the last content on the line. -->
 		<!-- Closing parenthesis of a multi-line function call must be on a line by itself. -->


### PR DESCRIPTION
Only the Underscore part of this sniff conflicts with Yii's coding standards: "Property names MUST start with an initial underscore if they are private."
The other checks should not be disabled.