### PR TITLE
Fixed the version of php_codesniffer to stay under 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,6 @@
 	},
 	"require": {
 		"php": ">=5.4.0",
-		"squizlabs/php_codesniffer": ">=2.3.1"
+		"squizlabs/php_codesniffer": ">=2.3.1 <3.0"
 	}
 }


### PR DESCRIPTION
While you are discussing over #32 it would be best to at least fix the dependancy version of php_codesniffer to stay under 3.0 since this version breaks BC with the current custom sniffs